### PR TITLE
Add wp_body_open function to theme header

### DIFF
--- a/header.php
+++ b/header.php
@@ -37,6 +37,8 @@
 
     <body <?php body_class(); ?>>
 
+        <?php wp_body_open(); ?>
+
         <div class="off-canvas-wrapper">
 
             <?php get_template_part( 'dt-assets/parts/nav', 'offcanvas' ); ?>


### PR DESCRIPTION
Hey guys - hopefully this is an easy add. It will allow people to hook into the theme directly after the body open tag.
https://developer.wordpress.org/reference/functions/wp_body_open/